### PR TITLE
feat: proxy 도입 후 액세스 토큰, 역할 기반 라우팅 설정

### DIFF
--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -31,7 +31,7 @@ export default function LoginForm() {
         role: state.data.role,
       });
       const from = searchParams.get("from") || "/";
-      router.push(from ? from : "/courses");
+      router.push(from);
     }
   }, [state, setUser, router]);
 

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -4,7 +4,7 @@ import { useEffect, useActionState } from "react";
 import { loginAction } from "../actions/login.action";
 import styles from "./LoginForm.module.css";
 import { useAuthStore } from "@/stores/useAuthStore";
-import { useRouter } from "next/navigation";
+import { useSearchParams, useRouter } from "next/navigation";
 import { useModalStore } from "@/stores/useModalStore";
 
 const initialState = {
@@ -19,6 +19,7 @@ export default function LoginForm() {
     initialState
   );
   const setUser = useAuthStore((state) => state.setUser);
+  const searchParams = useSearchParams();
   const router = useRouter();
   const { openModal } = useModalStore();
 
@@ -29,7 +30,8 @@ export default function LoginForm() {
         nickName: state.data.nickName,
         role: state.data.role,
       });
-      router.push("/courses");
+      const from = searchParams.get("from") || "/";
+      router.push(from ? from : "/courses");
     }
   }, [state, setUser, router]);
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,9 +6,6 @@ export function proxy(request: NextRequest) {
   const accessToken = request.cookies.get("accessToken")?.value;
   const { pathname } = request.nextUrl;
 
-  console.log("현재 경로:", pathname);
-  console.log("토큰 존재:", !!accessToken);
-
   // 인증 체크
   if (!accessToken) {
     const loginUrl = new URL("/login", request.url);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -31,7 +31,11 @@ export function proxy(request: NextRequest) {
   return NextResponse.next();
 }
 
+// 인증이 필요한 경로에서만 middleware 실행
 export const config = {
-  // 아래 경로들에만 proxy가 실행되는 것
-  matcher: ["/instructor/:path*", "/mypage/:path*", "/cart"],
+  matcher: [
+    "/instructor/:path*", // 강사 전용 페이지
+    "/mypage/:path*", // 마이페이지
+    "/cart", // 장바구니
+  ],
 };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { decodeJWT } from "./shared/utils/jwt";
+
+export function proxy(request: NextRequest) {
+  const accessToken = request.cookies.get("accessToken")?.value;
+  const { pathname } = request.nextUrl;
+
+  console.log("현재 경로:", pathname);
+  console.log("토큰 존재:", !!accessToken);
+
+  // 인증 체크
+  if (!accessToken) {
+    const loginUrl = new URL("/login", request.url);
+    // 로그인 후 돌아올 경로 저장
+    loginUrl.searchParams.set("from", pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  // 역할 체크
+  if (pathname.startsWith("/instructor")) {
+    const user = decodeJWT(accessToken);
+
+    if (!user || user.role !== "INSTRUCTOR") {
+      // INSTRUCTOR가 아니면 홈으로
+      return NextResponse.redirect(new URL("/", request.url));
+    }
+  }
+
+  // 모든 검증 통과 시
+  return NextResponse.next();
+}
+
+export const config = {
+  // 아래 경로들에만 proxy가 실행되는 것
+  matcher: ["/instructor/:path*", "/mypage/:path*", "/cart"],
+};

--- a/src/shared/lib/serverApi.ts
+++ b/src/shared/lib/serverApi.ts
@@ -1,8 +1,11 @@
 "use server";
 
 import { cookies } from "next/headers";
+import { refreshToken } from "@/services/auth.service";
+
 import { handleResponse } from "./api";
 import { ApiResponse } from "../types/types";
+
 const BASE_URL = process.env.API_BASE_URL || "http://localhost:8080/api/v1";
 
 export const fetchWithAuth = async <T = any>(
@@ -10,22 +13,65 @@ export const fetchWithAuth = async <T = any>(
   options: RequestInit = {}
 ): Promise<ApiResponse<T>> => {
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get("accessToken")?.value;
-
-  console.log("=== fetchWithAuth ===");
-  console.log("Endpoint:", endpoint);
-  console.log("AccessToken:", accessToken ? "존재" : "없음");
+  let accessToken = cookieStore.get("accessToken")?.value;
 
   const headers = {
-    "Content-Type": "application/json", //기본 헤더
-    ...(options.headers || {}), //호출하는 쪽에서 넣어준 헤더
-    ...((accessToken && { Authorization: `Bearer ${accessToken}` }) || {}), //토큰 있으면 Authorization 추가
+    "Content-Type": "application/json",
+    ...(options.headers || {}),
+    ...((accessToken && { Authorization: `Bearer ${accessToken}` }) || {}),
   };
 
-  const res = await fetch(`${BASE_URL}/${endpoint}`, {
+  let res = await fetch(`${BASE_URL}/${endpoint}`, {
     ...options,
     headers,
   });
 
+  // 401 에러면 토큰 갱신 후 재시도
+  if (res.status === 401) {
+    const refreshed = await refreshAccessToken();
+
+    if (refreshed) {
+      // 갱신 성공 - 새 토큰으로 재시도
+      const cookieStore = await cookies();
+      const newAccessToken = cookieStore.get("accessToken")?.value;
+
+      const retryHeaders = {
+        "Content-Type": "application/json",
+        ...(options.headers || {}),
+        ...((newAccessToken && { Authorization: `Bearer ${newAccessToken}` }) ||
+          {}),
+      };
+
+      res = await fetch(`${BASE_URL}/${endpoint}`, {
+        ...options,
+        headers: retryHeaders,
+      });
+    }
+  }
+
   return handleResponse<T>(res);
 };
+
+// 토큰 갱신 함수
+async function refreshAccessToken(): Promise<boolean> {
+  const cookieStore = await cookies();
+  const refreshTokenValue = cookieStore.get("refreshToken")?.value;
+
+  if (!refreshTokenValue) return false;
+
+  try {
+    const { accessToken } = await refreshToken({
+      refreshToken: refreshTokenValue,
+    });
+
+    cookieStore.set("accessToken", accessToken, {
+      httpOnly: true,
+      maxAge: 60 * 60,
+      path: "/",
+    });
+
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/shared/utils/jwt.ts
+++ b/src/shared/utils/jwt.ts
@@ -12,8 +12,7 @@ export function decodeJWT(
     const decoded = JSON.parse(atob(payload));
 
     return decoded;
-  } catch (error) {
-    console.error("JWT 디코딩 실패:", error);
+  } catch {
     return null;
   }
 }

--- a/src/shared/utils/jwt.ts
+++ b/src/shared/utils/jwt.ts
@@ -1,0 +1,19 @@
+export function decodeJWT(
+  token: string
+): { role?: string; nickName?: string } | null {
+  try {
+    // JWT 구조: header.payload.signature
+    // 자세한 내용은 노션 공부방 참조!
+    const parts = token.split(".");
+    if (parts.length !== 3) return null;
+
+    // payload 부분 (인덱스 1)을 Base64 디코딩
+    const payload = parts[1];
+    const decoded = JSON.parse(atob(payload));
+
+    return decoded;
+  } catch (error) {
+    console.error("JWT 디코딩 실패:", error);
+    return null;
+  }
+}


### PR DESCRIPTION
## 변경 사항

- Next.js Proxy를 사용한 서버 사이드 인증 기반 라우트 접근 제어
- 쿠키 기반 토큰 검증 및 자동 리다이렉션
- 역할(Role) 기반 페이지 접근 권한 관리 (STUDENT vs INSTRUCTOR)

## 리뷰 필요

다음 시나리오를 통해 잘 작동되는지 확인해주세요.
- [ ] 비로그인 상태에서 `/instructor` 접근 → `/login?from=/instructor`로 리다이렉션
- [ ] 비로그인 상태에서 `/mypage` 접근 → `/login?from=/mypage`로 리다이렉션
- [ ] STUDENT 역할로 `/instructor` 접근 → `/`로 리다이렉션
- [ ] INSTRUCTOR 역할로 `/instructor` 접근 → 정상 접근
- [ ] 로그인 후 `from` 파라미터로 원래 페이지로 복귀

close #48 
