### PR TITLE
refactor: input ui 분리 & 먼저 signup 페이지만

### DIFF
--- a/src/features/auth/actions/regist.action.ts
+++ b/src/features/auth/actions/regist.action.ts
@@ -1,10 +1,10 @@
-"use server";
+'use server';
 
-import {registerUser} from "@/services/auth.service";
-import {RegistRequest, ROLE} from "../types";
-import {validateRegistForm} from "../validate";
-import {isBackendError} from "@/shared/types/types";
-import {mapAuthError} from "../utils/authErrorMapper";
+import { registerUser } from '@/services/auth.service';
+import { RegistRequest, ROLE } from '../types';
+import { validateRegistForm } from '../validate';
+import { isBackendError } from '@/shared/types/types';
+import { mapAuthError } from '../utils/authErrorMapper';
 
 export type RegistFormData = {
   name: string;
@@ -18,11 +18,11 @@ export const registAction = async (
   prevState: ActionState<RegistFormData>,
   formData: FormData,
 ): Promise<ActionState<RegistFormData>> => {
-  const name = formData.get("name") as string;
-  const email = formData.get("email") as string;
-  const password = formData.get("password") as string;
-  const confirmPassword = formData.get("confirmPassword") as string;
-  const role = formData.get("role") as ROLE;
+  const name = formData.get('name') as string;
+  const email = formData.get('email') as string;
+  const password = formData.get('password') as string;
+  const confirmPassword = formData.get('confirmPassword') as string;
+  const role = formData.get('role') as ROLE;
 
   const validation = validateRegistForm({
     name,
@@ -34,7 +34,7 @@ export const registAction = async (
     return {
       success: false,
       errors: validation.errors,
-      data: {name, email, password: "", confirmPassword: "", role},
+      data: { name, email, password: '', confirmPassword: '', role },
     };
   }
 
@@ -50,7 +50,7 @@ export const registAction = async (
 
     return {
       success: true,
-      message: "회원가입이 성공적으로 완료되었습니다.",
+      message: '회원가입이 성공적으로 완료되었습니다.',
     };
   } catch (error) {
     // 백엔드 에러 코드 기반으로 매핑
@@ -61,7 +61,7 @@ export const registAction = async (
     // 예상치 못한 에러
     return {
       success: false,
-      message: "알 수 없는 에러가 발생했습니다.",
+      message: '알 수 없는 에러가 발생했습니다.',
     };
   }
 };

--- a/src/features/auth/components/LoginForm.module.css
+++ b/src/features/auth/components/LoginForm.module.css
@@ -7,49 +7,5 @@
   color: var(--gray-900);
 }
 
-.field {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
 
-.label {
-  font-size: var(--text-base);
-  font-weight: var(--font-medium);
-  color: var(--gray-700);
-}
 
-.input {
-  width: 100%;
-  height: 3.5rem;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--gray-200);
-  padding: 0 1rem;
-  font-size: var(--text-base);
-  font-family: inherit;
-  color: var(--gray-900);
-  background-color: var(--gray-00);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.input::placeholder {
-  color: var(--gray-500);
-}
-
-.input:focus {
-  outline: none;
-  border-color: var(--primary-400);
-  box-shadow: 0 0 0 3px rgba(39, 179, 244, 0.25);
-}
-
-.errorMessage {
-  display: block;
-  padding: 0.5rem 0.75rem;
-  margin-top: 0.5rem;
-  border-radius: var(--radius-sm);
-  background-color: rgba(215, 4, 102, 0.08);
-  color: var(--primary-400);
-  font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  text-align: center;
-}

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -1,24 +1,22 @@
-"use client";
+'use client';
 
-import { useEffect, useActionState } from "react";
-import { loginAction } from "../actions/login.action";
-import styles from "./LoginForm.module.css";
-import { useAuthStore } from "@/stores/useAuthStore";
-import { useSearchParams, useRouter } from "next/navigation";
-import { useModalStore } from "@/stores/useModalStore";
-import { Button } from "@/shared/components/ui/button/Button";
+import { useEffect, useActionState } from 'react';
+import { loginAction } from '../actions/login.action';
+import styles from './LoginForm.module.css';
+import { useAuthStore } from '@/stores/useAuthStore';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { useModalStore } from '@/stores/useModalStore';
+import { Button } from '@/shared/components/ui/button/Button';
+import FieldInput from '@/shared/components/ui/FieldInput';
 
 const initialState = {
   success: false,
-  message: "",
+  message: '',
   errors: {},
 };
 
 export default function LoginForm() {
-  const [state, formAction, isPending] = useActionState(
-    loginAction,
-    initialState,
-  );
+  const [state, formAction, isPending] = useActionState(loginAction, initialState);
   const setUser = useAuthStore((state) => state.setUser);
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -31,7 +29,7 @@ export default function LoginForm() {
         nickname: state.data.nickname,
         role: state.data.role,
       });
-      const callback = searchParams.get("callback") || "/";
+      const callback = searchParams.get('callback') || '/';
       // proxy가 /login으로 리다이렉트할 때 URL에 추가한 복귀 경로
       router.push(callback);
     }
@@ -41,7 +39,7 @@ export default function LoginForm() {
   useEffect(() => {
     if (!state.success && state.message) {
       openModal({
-        title: "로그인 실패",
+        title: '로그인 실패',
         message: state.message,
       });
     }
@@ -49,32 +47,23 @@ export default function LoginForm() {
 
   return (
     <form action={formAction} className={styles.form}>
-      <label className={styles.field}>
-        <span className={styles.label}>이메일</span>
-        <input
-          name="email"
-          className={styles.input}
-          type="email"
-          placeholder="Enter your email"
-        />
-        {state.errors?.email && (
-          <span className={styles.errorMessage}>{state.errors.email}</span>
-        )}
-      </label>
-      <label className={styles.field}>
-        <span className={styles.label}>비밀번호</span>
-        <input
-          name="password"
-          className={styles.input}
-          type="password"
-          placeholder="Enter your password"
-        />
-        {state.errors?.password && (
-          <span className={styles.errorMessage}>{state.errors.password}</span>
-        )}
-      </label>
+      <FieldInput
+        label="이메일"
+        name="email"
+        type="email"
+        placeholder="Enter your email"
+        errorMessage={state.errors.email}
+      />
+      <FieldInput
+        label="비밀번호"
+        name="password"
+        type="password"
+        placeholder="Enter your password"
+        errorMessage={state.errors.password}
+      />
+
       <Button variant="submit" type="submit">
-        {isPending ? "로그인 하는 중..." : "로그인"}
+        {isPending ? '로그인 하는 중...' : '로그인'}
       </Button>
     </form>
   );

--- a/src/shared/components/ui/ErrorMessage.module.css
+++ b/src/shared/components/ui/ErrorMessage.module.css
@@ -1,0 +1,11 @@
+.errorMessage {
+  display: block;
+  padding: 0.5rem 0.75rem;
+  margin-top: 0.5rem;
+  border-radius: var(--radius-sm);
+  background-color: rgba(215, 4, 102, 0.08);
+  color: var(--primary-400);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  text-align: center;
+}

--- a/src/shared/components/ui/ErrorMessage.tsx
+++ b/src/shared/components/ui/ErrorMessage.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import styles from './ErrorMessage.module.css';
+
+export default function ErrorMessage({ errorMessage }: { errorMessage: string }) {
+  return <span className={styles.errorMessage}>{errorMessage}</span>;
+}

--- a/src/shared/components/ui/FieldInput.module.css
+++ b/src/shared/components/ui/FieldInput.module.css
@@ -1,0 +1,11 @@
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.label {
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  color: var(--gray-700);
+}

--- a/src/shared/components/ui/FieldInput.tsx
+++ b/src/shared/components/ui/FieldInput.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styles from './FieldInput.module.css';
+import Input from '@/shared/components/ui/Input';
+import ErrorMessage from '@/shared/components/ui/ErrorMessage';
+
+type FieldInputProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  icon?: React.ReactNode;
+  errorMessage?: string;
+  label: string;
+};
+
+export default function FieldInput(props: FieldInputProps) {
+  const { icon, label, errorMessage, ...rest } = props;
+  return (
+    <label className={styles.field}>
+      <span className={styles.label}>{label}</span>
+      <Input {...rest} />
+      {errorMessage && <ErrorMessage errorMessage={errorMessage} />}
+    </label>
+  );
+}

--- a/src/shared/components/ui/Input.module.css
+++ b/src/shared/components/ui/Input.module.css
@@ -1,0 +1,22 @@
+.input {
+  width: 100%;
+  height: 3.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--gray-200);
+  padding: 0 1rem;
+  font-size: var(--text-base);
+  font-family: inherit;
+  color: var(--gray-900);
+  background-color: var(--gray-00);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input::placeholder {
+  color: var(--gray-500);
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--primary-400);
+  box-shadow: 0 0 0 3px rgba(39, 179, 244, 0.25);
+}

--- a/src/shared/components/ui/Input.tsx
+++ b/src/shared/components/ui/Input.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import styles from "./Input.module.css";
+
+type BaseInputProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  icon?: React.ReactNode
+}
+
+export default function Input({ icon, ...props }: BaseInputProps) {
+  const { className, placeholder, ...rest } = props
+
+  return (
+    <div style={{position: 'relative'}}>
+      <input
+        {...rest}
+        className={`${styles.input} ${className}`}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
## 변경 사항

- 로그인 페이지 [email, password] 공통 input 으로 수정 
- Input, FeildInput 공통 컴포넌트 생성

## 리뷰 필요

- 분리 된 컴포넌트 확인 
- 로그인 페이지만 공통 ui로 넣음

close
