### PR TITLE
refactor: 로그인/회원가입 경로 및 인증 실패 시 사용자 상태 초기화 처리

### DIFF
--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -6,12 +6,13 @@ export async function GET() {
     const me = await getMe();
     return NextResponse.json(me, { status: 200 });
   } catch (error) {
-    console.error("[/api/me] error:", error);
-
     const message =
       error instanceof Error ? error.message : "Internal Server Error";
-    const status =
-      typeof (error as any)?.status === "number" ? (error as any).status : 500;
+    const status = typeof error?.status === "number" ? error.status : 500;
+
+    if (status === 401) {
+      return NextResponse.json({ message: "unauthorized" }, { status: 401 });
+    }
 
     return NextResponse.json({ message }, { status });
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,3 @@
-import Image from "next/image";
-
 export default function Home() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">

--- a/src/features/mypage/components/MySidebar.tsx
+++ b/src/features/mypage/components/MySidebar.tsx
@@ -8,12 +8,8 @@ import Avatar from "@/shared/components/ui/avatar/Avatar/Avatar";
 import { Button } from "@/shared/components/ui/button/Button";
 
 export default function MySidebar() {
-  const { userProfile, clearUser } = useAuthStore((state) => ({
-    userProfile: state.userProfile,
-    clearUser: state.clearUser,
-  }));
-  // const userProfile = useAuthStore((state)=>(state.useProfile)
-  // const clearUser = useAuthStore((state)=>state.clearUser)
+  const userProfile = useAuthStore((state) => state.userProfile);
+  const clearUser = useAuthStore((state) => state.clearUser);
 
   const handleLogout = async () => {
     clearUser(); // zustand 상태 초기화 (localStorage도 자동 반영)
@@ -30,11 +26,7 @@ export default function MySidebar() {
         <Link href="/mypage/enrollment" className={styles.navItem}>
           수강 중인 강좌
         </Link>
-        <Button
-          variant="navItem"
-          type="button"
-          onClick={handleLogout}
-        >
+        <Button variant="navItem" type="button" onClick={handleLogout}>
           로그아웃
         </Button>
       </nav>

--- a/src/shared/components/initializer/AuthInitializer.tsx
+++ b/src/shared/components/initializer/AuthInitializer.tsx
@@ -3,6 +3,7 @@
 import { ROLE } from "@/features/auth/types";
 import { useAuthStore } from "@/stores/useAuthStore";
 import { useEffect } from "react";
+import { usePathname } from "next/dist/client/components/navigation";
 
 type MeResponse = {
   id: number;
@@ -17,8 +18,13 @@ type MeResponse = {
 export default function AuthInitializer() {
   const setUser = useAuthStore((state) => state.setUser); // 함수 가져오기
   const clearUser = useAuthStore((state) => state.clearUser); // 함수 가져오기
+  const pathname = usePathname();
 
   useEffect(() => {
+    if (pathname === "/login" || pathname === "/signup") {
+      clearUser();
+      return;
+    }
     let ignore = false;
     const fetchUser = async () => {
       try {
@@ -26,10 +32,15 @@ export default function AuthInitializer() {
           cache: "no-store",
           credentials: "include",
         });
-        console.log("status", res.status);
-        console.log("set-cookie?", res.headers.get("set-cookie")); // route handler에서만 의미
-
-        if (!res.ok) throw new Error("unauthorized");
+        if (res.status === 401) {
+          // 로그인 안 한 상태는 정상 상태
+          clearUser();
+          return;
+        }
+        if (!res.ok) {
+          // 서버 문제(500 등)만 로깅/에러 UI 처리
+          throw new Error("ME API failed");
+        }
         const me: MeResponse = await res.json();
         if (!ignore) {
           setUser({ nickname: me.nickname, role: me.role });
@@ -45,7 +56,7 @@ export default function AuthInitializer() {
     return () => {
       ignore = true;
     };
-  }, [setUser, clearUser]);
+  }, [setUser, clearUser, pathname]);
 
   return null;
 }

--- a/src/shared/components/layout/UserActions.tsx
+++ b/src/shared/components/layout/UserActions.tsx
@@ -27,6 +27,8 @@ export default function UserActions() {
       <Link href="/cart" className={styles.actionButton} aria-label="장바구니">
         <Image
           src="/assets/shopping-cart.svg"
+          width={10}
+          height={10}
           alt=""
           className={styles.actionIcon}
           aria-hidden="true"
@@ -37,7 +39,13 @@ export default function UserActions() {
         className={styles.actionButton}
         aria-label="마이페이지"
       >
-        <Image src="/assets/user.svg" alt="" className={styles.actionIcon} />
+        <Image
+          src="/assets/user.svg"
+          width={10}
+          height={10}
+          alt=""
+          className={styles.actionIcon}
+        />
       </Link>
     </div>
   );


### PR DESCRIPTION
## 변경 사항

- /login, /signup 경로 진입 시 AuthInitializer에서 /api/me 호출을 생략하고 clearUser()로 store 초기화
- /api/me 응답이 401인 경우 비로그인 정상 상태로 처리하여 clearUser()로 store 동기화
- Next.js Image 컴포넌트 사용처에서 width/height 누락된 이미지에 속성 추가하여 경고 및 레이아웃 시프트 방지

## 리뷰 필요

close #70 
