### PR TITLE
refactor: 공통 handleResponse 로직 안정화

### DIFF
--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -9,32 +9,27 @@ import { getCourses } from "@/services/course.service";
 import { Category } from "@/features/courses/types";
 import Link from "next/link";
 
+type CoursePageSearchParams = {
+  categoryId?: string;
+  search?: string;
+  sort?: string;
+};
 export default async function CoursePage({
   searchParams,
 }: {
-  searchParams: Promise<{
-    categoryId?: string;
-    search?: string;
-    sort?: string;
-  }>;
+  searchParams: CoursePageSearchParams;
 }) {
-  const params = await searchParams;
-
-  const categoryQuery = params.categoryId || "";
-  const searchQuery = params.search || "";
-  const sortQuery = params.sort || "";
-
-  const apiParams = {
-    categoryId: categoryQuery,
-    search: searchQuery,
-    sort: sortQuery,
-    limit: "10",
-  };
+  const categoryQuery = searchParams.categoryId || "";
+  const searchQuery = searchParams.search || "";
+  const sortQuery = searchParams.sort || "";
 
   const { contents: categories } = await getAllCategories();
 
   let subCategories: Category[] = [];
   let categoryName = "";
+
+  // categoryId 없을 때는 courses 호출하지 않도록 기본값 세팅
+  let courses: any[] = [];
 
   if (categoryQuery) {
     const currentCategory = await getCategoriesById(categoryQuery);
@@ -48,14 +43,21 @@ export default async function CoursePage({
     } else {
       // 2차 카테고리 → 부모 카테고리의 subCategories 가져오기
       const parentCategory = await getCategoriesById(
-        String(currentCategory.parentId)
+        String(currentCategory.parentId),
       );
       categoryName = currentCategory.name;
       subCategories = parentCategory.subCategories ?? [];
     }
+    // categoryQuery 있을 때만 호출
+    const apiParams = {
+      categoryId: categoryQuery,
+      search: searchQuery,
+      sort: sortQuery,
+      limit: "10",
+    };
+    const { contents } = await getCourses(apiParams);
+    courses = contents;
   }
-
-  const { contents: courses } = await getCourses(apiParams);
 
   const pageTitle = searchQuery
     ? `"${searchQuery}" 검색 결과`

--- a/src/shared/lib/api.ts
+++ b/src/shared/lib/api.ts
@@ -4,34 +4,52 @@ const BASE_URL = process.env.API_BASE_URL || "http://localhost:8080/api/";
  * HTTP Response를 처리하고 에러 시 throw
  * @throws {BackendError} HTTP 에러 발생 시
  */
-const handleResponse = async <T>(res: Response): Promise<T> => {
+type ApiError = {
+  status: number;
+  code?: string;
+  message?: string;
+  errors?: unknown;
+};
+
+const handleResponse = async <T>(res: Response): Promise<T | null> => {
+  const text = await res.text();
+  const contentType = res.headers.get("content-type") ?? "";
+
   // 에러 응답 처리
   if (!res.ok) {
-    let errorBody = null;
-
-    try {
-      errorBody = await res.json();
-    } catch {
-      // JSON 파싱 실패 - 백엔드에서 정의하지 못한 에러
-      errorBody = { message: "알 수 없는 에러가 발생했습니다" };
+    let errorBody: any = null;
+    if (text && contentType.includes("application/json")) {
+      try {
+        errorBody = JSON.parse(text);
+      } catch {
+        //백엔드 에러가 JSON 아닐 경우 프론트에서 JSON.parse가 실패로 터지지 않게 하기 위해
+        errorBody = null;
+      }
     }
 
-    throw {
+    const error: ApiError = {
       status: res.status,
       code: errorBody?.code,
-      message: errorBody?.message || res.statusText,
+      message:
+        errorBody?.message ||
+        res.statusText ||
+        "알 수 없는 에러가 발생했습니다",
       errors: errorBody?.errors,
+    };
+    throw error;
+  }
+
+  // 204 or empty body
+  if (!text) return null;
+
+  // 성공인데 JSON이 아니면 버그로 판단
+  if (!contentType.includes("application/json")) {
+    throw {
+      status: res.status,
+      message: `JSON 응답을 기대했지만 content-type이 ${contentType} 입니다.`,
     };
   }
 
-  // 204 No Content
-  if (res.status === 204) {
-    return null as T;
-  }
-
-  // 성공(200): 응답 바디 비어있음 ""
-  const text = await res.text();
-  if (!text) return null as T;
   return JSON.parse(text) as T;
 };
 


### PR DESCRIPTION
## 변경 사항

- `res.headers.get("content-type")` 사용으로 헤더 접근 방식 수정
- body를 `await res.text()`로 1회만 읽고, 에러 응답 시 `JSON.parse(text)`로 파싱
- `res.ok === false`일 때 JSON 파싱 실패 시 fallback 메시지로 표준 에러 객체 생성
- 성공 응답에서 `content-type`이 JSON이 아니면 예외 throw (버그 조기 감지)
- `204 No Content` 및 빈 문자열 바디("") 처리 정리 (`null` 반환 또는 호출부 정책 결정)

## 리뷰 필요

close #73 
